### PR TITLE
Clarifying and fixing typo

### DIFF
--- a/sites/en/job-board/make_the_form_work.step
+++ b/sites/en/job-board/make_the_form_work.step
@@ -61,7 +61,7 @@ MARKDOWN
 message <<-MARKDOWN
   # Saving form data!
 
-  Head back to <http://localhost:3000/jobs/new>, and get your Rails console and your browser next to eachother again. Submit the form again, this time looking for the section that looks something like:
+  Head back to <http://localhost:3000/jobs/new>, and get your Rails server logs and your browser next to each other again. Submit the form again, this time looking for the section that looks something like:
 MARKDOWN
 
 source_code :http,


### PR DESCRIPTION
"Rails console" wasn't immediately clear to me, so replaced it with "Rails sever log" which matches how the server log is referenced in the box above. Also noticed and fixed the "eachother" typo.
